### PR TITLE
🐛뒤로 가기 시 즉시 페이지에서 나가지는 버그 수정

### DIFF
--- a/src/hooks/useRouteNavigation.ts
+++ b/src/hooks/useRouteNavigation.ts
@@ -9,10 +9,10 @@ export const useRouteNavigation = () => {
 
   return {
     toSurveyList: () => {
-      void navigate(SURVEY_LIST, { replace: true });
+      void navigate(SURVEY_LIST);
     },
     toSurveyDetail: ({ surveyId }: { surveyId: string }) => {
-      void navigate(CREATE.SURVEY_DETAIL({ surveyId }), { replace: true });
+      void navigate(CREATE.SURVEY_DETAIL({ surveyId }));
     },
   };
 };


### PR DESCRIPTION
### 📝 작업 내용

- replace true 옵션을 삭제하여 라우터 간 이동 내역을 저장힙니다.
- 뒤로 가기 시 즉시 페이지에서 나가지 않도록 합니다.

### 📸 스크린샷 (선택)

### 🚀 리뷰 요구사항 (선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
